### PR TITLE
refactor(manifest): 版本号从 package.json 读取，单一数据源

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,10 +1,14 @@
+import { createRequire } from 'node:module'
 import { isDev, port } from './utils/config.js'
+
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json')
 
 export const getManifest = () => {
   const m = {
     manifest_version: 3,
     name: 'Vue Chrome Extension',
-    version: '0.0.0',
+    version: pkg.version,
     icons: {
       16: 'dist/icons/logo-16.png',
       32: 'dist/icons/logo-32.png',


### PR DESCRIPTION
### Description
- 重构 manifest 版本号管理逻辑，将 `manifest.js` 中的 `version` 字段改为从 `package.json` 动态读取
- 移除 manifest 文件中硬编码的版本号，实现版本号「单一数据源」管理
- 后续发布仅需修改 `package.json` 版本号（或使用 `npm version` 命令），无需手动同步多个文件

### Motivation & Context
- 解决手动维护 `package.json` 和 `manifest.js` 双版本号易漏改、导致商店版本与 release tag 不一致的问题
- 降低版本号维护的心智负担，符合前端/Node 项目「单一 version 来源」的通用最佳实践
- 提升版本一致性，便于问题排查和用户反馈溯源