### PR TITLE
fix:修改default_popup路径

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -12,7 +12,7 @@ export const getManifest = () => {
       128: 'dist/icons/logo-128.png',
     },
     action: {
-      default_popup: 'dist/src/popup/index.html',
+      default_popup: 'dist/src/ui/popup/index.html',
       default_icon: {
         16: 'dist/icons/logo-16.png',
         32: 'dist/icons/logo-32.png',


### PR DESCRIPTION
manifest.json文件中的default_popup路径与打包产物路径不匹配，chrome报错
<img width="1470" height="836" alt="Snipaste_2026-02-10_14-40-35" src="https://github.com/user-attachments/assets/455cf04d-732a-4629-b851-d44b9d83b58f" />

